### PR TITLE
Update docusaurus.config.js to enable algolia search widget

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,7 @@ function getConfig() {
       en: "Developer resources for building on Conflux. By developers, for developers.",
       "zh-CN": "在Conflux上构建的开发者资源。由开发者提供，面向开发者。",
     }),
-    url: "https://doc.confluxnetwork.org/",
+    url: process.env.DOCUSAURUS_URL || "https://doc.confluxnetwork.org/",
     baseUrl: "/",
     onBrokenLinks: "warn",
     onBrokenMarkdownLinks: "warn",
@@ -307,35 +307,28 @@ function getConfig() {
           darkTheme: darkCodeTheme,
           additionalLanguages: ["solidity"],
         },
-        // algolia: {
-        //   // The application ID provided by Algolia
-        //   appId: 'EA5TTCRZGT',
+        metadata: [
+          { name: 'algolia-site-verification', content: process.env.ALGOLIA_VERIFY || 'YOUR_ALGOLIA_VERIFY' },
+        ],
 
-        //   // Public API key: it is safe to commit it
-        //   apiKey: '459281c476ae57d1d2a275ea535cdf1c',
+        algolia: {
+          // The application ID provided by Algolia
+          appId: process.env.ALGOLIA_APP_ID || 'YOUR_ALGOLIA_APP_ID',
 
-        //   indexName: 'confluxnetwork',
-        //   /*
-        //   // Optional: see doc section below
-        //   contextualSearch: true,
+          // Public API key: it is safe to commit it
+          apiKey: process.env.ALGOLIA_API_KEY || 'YOUR_SEARCH_API_KEY',
 
-        //   // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-        //   externalUrlRegex: 'external\\.com|domain\\.com',
+          indexName: process.env.ALGOLIA_INDEX_NAME || 'YOUR_INDEX_NAME',
 
-        //   // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-        //   replaceSearchResultPathname: {
-        //   from: '/docs/', // or as RegExp: /\/docs\//
-        //   to: '/docs/',
-        //   },
-        //   */
-        //   // Optional: Algolia search parameters
-        //   searchParameters: {},
+          // Optional: see doc section below
+          contextualSearch: true,
 
-        //   // Optional: path for search page that enabled by default (`false` to disable it)
-        //   searchPagePath: 'search',
+          // Optional: path for search page that enabled by default (`false` to disable it)
+          searchPagePath: 'search',
 
-        //   //... other Algolia params
-        //   },
+          // Optional: whether the insights feature is enabled or not on Docsearch (`false` by default)
+          insights: false,
+        },
       }),
   };
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -313,12 +313,12 @@ function getConfig() {
 
         algolia: {
           // The application ID provided by Algolia
-          appId: process.env.ALGOLIA_APP_ID || 'YOUR_ALGOLIA_APP_ID',
+          appId: process.env.ALGOLIA_APP_ID || '6UZZOVC2KR',
 
           // Public API key: it is safe to commit it
-          apiKey: process.env.ALGOLIA_API_KEY || 'YOUR_SEARCH_API_KEY',
+          apiKey: process.env.ALGOLIA_API_KEY || 'a5f90a9e6494b49f4ed7b08e1aef2764',
 
-          indexName: process.env.ALGOLIA_INDEX_NAME || 'YOUR_INDEX_NAME',
+          indexName: process.env.ALGOLIA_INDEX_NAME || 'doc_confluxnetwork_org_6uzzovc2kr_pages',
 
           // Optional: see doc section below
           contextualSearch: true,


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://doc.confluxnetwork.org/docs/general/CONTRIBUTING#create-a-pull-request).
- [ ] A relating issue is created: # (<- fill the issue number here)
- [x] **This is NOT a PR to submit translation**

As requested by @0xn1c0,  I  enabled the search widget for the CDP, the simplest way was to leverage Algolia search widget already integrated with Docusaurus.

Here a deployed example can be found: https://conflux-documentation-phi.vercel.app/

Code-Wise, only a few lines are needed in the docusaurus.config.js, but to integrate with Algolia multiple steps need to be done on their website to create the configuration and index the data.

these 4 values need to be filled in to work properly:
ALGOLIA_VERIFY
ALGOLIA_APP_ID
ALGOLIA_API_KEY
ALGOLIA_INDEX_NAME

These value can either be set as env vars or set in the defaulting value in the docusaurus.config.js itself 

Algolia offer a wizard to confgure a new application:

- is important to select DocSearch as search plan

- the domain should match the one in the docosaurus.config.js ("https://doc.confluxnetwork.org/") and once the initial configuration is completed needs to be verified (ALGOLIA_VERIFY)

- The crawler configuration once the setup is complete need to be set so there are no link limit, otherwise only few hundreds item will be indexed, also the name chosen for the crawler will be the value for ALGOLIA_INDEX_NAME

- At the end the wizard will ask if you are ready for the implementation, saying yes will show the ALGOLIA_APP_ID and ALGOLIA_API_KEY 

If needed I can give access to the currently configured Algolia dashboard, or for any question you can contact me on telegram (@SP_Nds) or discord (spcfxda)