### PR TITLE
Add diagnostic_getRateLimitStatus method

### DIFF
--- a/docs/core/core-endpoints.md
+++ b/docs/core/core-endpoints.md
@@ -99,6 +99,21 @@ Here are references for various fee tiers and their rate limits.
 | trace RPC | not supported | QPS < 20 | includes: <br/> `trace_block`, `trace_filter`, `trace_transaction` |
 | filter API | not supported | supported | includes: <br/> `cfx_newFilter`, `cfx_getFilterChanges` etc. |
 
+A diagnostic method `diagnostic_getRateLimitStatus` has been provided for users to **check their current rate-limit status**.
+
+**Usage Example:**
+
+```bash
+curl --location 'https://main.confluxrpc.com/<api-key>' \
+--header 'Content-Type: application/json' \
+--data '{
+  "jsonrpc":"2.0",
+  "method":"diagnostic_getRateLimitStatus",
+  "params":[],
+  "id":1
+}'
+```
+
 </details>
 
 import ConfuraError from '../templates/confura-error.md'


### PR DESCRIPTION
Added a diagnostic method to check rate-limit status with usage example.

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://doc.confluxnetwork.org/docs/general/CONTRIBUTING#create-a-pull-request).
- [x] A relating issue is created: # (<- fill the issue number here)
- [x] **This is NOT a PR to submit translation**
