### PR TITLE
[codex] Highlight eSpace Foundry `-g` guidance

### DIFF
--- a/docs/espace/DeveloperQuickstart.md
+++ b/docs/espace/DeveloperQuickstart.md
@@ -92,6 +92,18 @@ To deploy using the eSpace Testnet Public RPC, run:
 forge create ... --rpc-url=https://evmtestnet.confluxrpc.com
 ```
 
+:::caution
+
+When running `forge script` on Conflux eSpace, add `-g 250` to the command. Conflux eSpace gas accounting differs from Ethereum, and using the recommended multiplier helps avoid "insufficient gas fee" errors.
+
+Example:
+
+```bash
+forge script script/Counter.s.sol --rpc-url https://evmtestnet.confluxrpc.com --broadcast -g 250
+```
+
+:::
+
 A complete workflow for using foundry deploy contract is shown [here](./tutorials/deployContract/hardhatAndFoundry.md)
 
 ### Remix Web IDE

--- a/docs/espace/tutorials/deployContract/hardhatAndFoundry.md
+++ b/docs/espace/tutorials/deployContract/hardhatAndFoundry.md
@@ -83,6 +83,12 @@ import TabItem from '@theme/TabItem';
 
 ## Deploying smart contracts with Foundry
 
+:::caution Important for Conflux eSpace
+
+When using `forge script` on Conflux eSpace, add `-g 250`. This is the recommended gas price multiplier for eSpace and helps avoid "insufficient gas fee" errors.
+
+:::
+
 1. Clone the repo:
 
    ```shell
@@ -124,10 +130,10 @@ import TabItem from '@theme/TabItem';
 
 ### forge script
 
-Because some opcodes in Conflux eSpace consume twice the amount of gas compared to Ethereum, when using the `forge script` command to execute a script, you need to pass an additional parameter (-g 200) to increase the gas limit. Otherwise, the transaction will fail after being sent to the chain due to Insufficient gas fee.
+Because some opcodes in Conflux eSpace consume more gas than on Ethereum, when using the `forge script` command to execute a script, you should pass the additional parameter `-g 250`. Otherwise, the transaction may fail after being sent to the chain due to insufficient gas fee.
 
 ```shell
-forge script script/Counter.s.sol --rpc-url https://evmtestnet.confluxrpc.com --private-key 0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1 --broadcast -g 200
+forge script script/Counter.s.sol --rpc-url https://evmtestnet.confluxrpc.com --private-key 0xabc123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc1 --broadcast -g 250
 ```
 
 ## FAQs

--- a/docs/espace/tutorials/upgradableContract/transparent-proxy-foundry.md
+++ b/docs/espace/tutorials/upgradableContract/transparent-proxy-foundry.md
@@ -247,13 +247,19 @@ RPC_URL=https://evmtestnet.confluxrpc.com
 
 ## Deployment Process
 
+:::caution
+
+When using `forge script` on Conflux eSpace, append `-g 250` to the command. This is the recommended value and helps avoid "insufficient gas fee" errors.
+
+:::
+
 1. Deploy the initial implementation and proxy:
 
 ```bash
 source .env
-forge script script/DeployBox.s.sol --rpc-url $RPC_URL --broadcast -g 200
+forge script script/DeployBox.s.sol --rpc-url $RPC_URL --broadcast -g 250
 ```
-> **Note:** The `-g` flag sets the gas price multiplier (in percentage). Using `-g 200` means the gas price will be 200% of the estimated price, which helps prevent "insufficient gas fee" errors during deployment.
+> **Note:** The `-g` flag sets the gas price multiplier. On Conflux eSpace, `-g 250` is the recommended value for `forge script` commands.
 
 Expected output:
 ```
@@ -273,7 +279,7 @@ ADMIN_ADDRESS=<ADMIN_ADDRESS>
 3. Upgrade to BoxV2:
 
 ```bash
-forge script script/UpgradeBox.s.sol --rpc-url $RPC_URL --broadcast -g 200
+forge script script/UpgradeBox.s.sol --rpc-url $RPC_URL --broadcast -g 250
 ```
 
 

--- a/docs/espace/tutorials/upgradableContract/upgrade-foundry.md
+++ b/docs/espace/tutorials/upgradableContract/upgrade-foundry.md
@@ -221,6 +221,12 @@ contract TestAfterUpgradeScript is Script {
 
 ## 7. Deployment and Upgrade Process
 
+:::caution
+
+When using `forge script` on Conflux eSpace, append `-g 250` to deployment and upgrade commands. This is the recommended value and helps avoid "insufficient gas fee" errors.
+
+:::
+
 1. Set up environment variables:
 
 Create a `.env` file in the project root:
@@ -233,9 +239,9 @@ PROXY_ADDRESS=
 2. Deploy the initial contract:
 
 ```bash
-forge script script/Deploy.s.sol:DeployScript --rpc-url espaceTestnet --broadcast -g 200
+forge script script/Deploy.s.sol:DeployScript --rpc-url espaceTestnet --broadcast -g 250
 ```
-> **Note:** The `-g` flag sets the gas price multiplier (in percentage). Using `-g 200` means the gas price will be 200% of the estimated price, which helps prevent "insufficient gas fee" errors during deployment. 
+> **Note:** The `-g` flag sets the gas price multiplier. On Conflux eSpace, `-g 250` is the recommended value for `forge script` commands.
 
 Expected output:
 ```
@@ -260,7 +266,7 @@ Current implementation address: 0x...(Logic1's address)
 5. Upgrade the contract:
 
 ```bash
-forge script script/Upgrade.s.sol:UpgradeScript --rpc-url espaceTestnet --broadcast -g 200
+forge script script/Upgrade.s.sol:UpgradeScript --rpc-url espaceTestnet --broadcast -g 250
 ```
 
 6. Run the post-upgrade test:

--- a/docs/espace/tutorials/upgradableContract/uups-foundry.md
+++ b/docs/espace/tutorials/upgradableContract/uups-foundry.md
@@ -329,14 +329,20 @@ contract CounterTest is Test {
 
 ## Deployment and Upgrade Process
 
+:::caution
+
+When using `forge script` on Conflux eSpace, append `-g 250` to deployment and upgrade commands. This is the recommended value and helps avoid "insufficient gas fee" errors.
+
+:::
+
 1. Deploy the initial implementation and proxy:
 
 ```bash
 source .env
-forge script script/DeployCounter.s.sol --rpc-url $RPC_URL --broadcast -g 200
+forge script script/DeployCounter.s.sol --rpc-url $RPC_URL --broadcast -g 250
 ```
 
-> **Note:** The `-g` flag sets the gas price multiplier (in percentage). Using `-g 200` means the gas price will be 200% of the estimated price, which helps prevent "insufficient gas fee" errors during deployment.
+> **Note:** The `-g` flag sets the gas price multiplier. On Conflux eSpace, `-g 250` is the recommended value for `forge script` commands.
 
 Expected output:
 ```
@@ -355,7 +361,7 @@ PROXY_ADDRESS=<PROXY_ADDRESS>
 3. Upgrade to CounterV2:
 
 ```bash
-forge script script/UpgradeCounter.s.sol --rpc-url $RPC_URL --broadcast -g 200
+forge script script/UpgradeCounter.s.sol --rpc-url $RPC_URL --broadcast -g 250
 ```
 
 Expected output:
@@ -377,5 +383,4 @@ Count after reset: 0
 ```
 
 By following these steps, you can deploy and upgrade smart contracts using UUPS proxy pattern on Conflux eSpace with Foundry. This pattern provides a more gas-efficient alternative to the transparent proxy pattern while maintaining upgradeability. The UUPS pattern moves the upgrade logic to the implementation contract, making it more lightweight and cost-effective for users.
-
 


### PR DESCRIPTION
## Summary
- make the eSpace Foundry `-g` guidance more prominent in the quickstart and tutorial entry points
- update eSpace Foundry script examples to recommend `-g 250`
- align upgradeable contract tutorials with the same recommendation

## Why
Issue #968 points out that the current `-g` guidance exists but is too easy to miss. Users following the eSpace Foundry docs can miss the required flag and run into avoidable `insufficient gas fee` failures.

## Validation
- `git diff --check`
- reviewed the updated docs to confirm `forge script` examples now consistently use `-g 250`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/971)
<!-- Reviewable:end -->
