### PR TITLE
[codex] Add Conflux Skills guide and entry links

### DIFF
--- a/docs/core/core-developer-quickstart.md
+++ b/docs/core/core-developer-quickstart.md
@@ -33,6 +33,12 @@ Ethereum SDKs (ethers.js, web3.js, web3,py, web3j) are not compatible with Confl
 
 :::
 
+:::tip
+
+Looking for reusable prompts and agent workflows for Conflux development? Start with [Conflux Skills](../general/build/conflux-skills.md).
+
+:::
+
 ## Introduction
 
 [**js-conflux-sdk**](https://github.com/conflux-chain/js-conflux-sdk) is a JavaScript SDK for Conflux Core Space. It is a collection of libraries that allow you to interact with a local or remote Conflux node using HTTP, WebSocket. You can use it to send transactions, deploy and interact with smart contracts, and so on.

--- a/docs/espace/DeveloperQuickstart.md
+++ b/docs/espace/DeveloperQuickstart.md
@@ -25,6 +25,12 @@ Since eSpace is EVM-Compatible, you’ll just need to point your favorite builde
 
 If you are not familiar with Ethereum development, you can start by learning the basics and understanding its stack through [Ethereum's official documentation](https://ethereum.org/en/developers/)
 
+:::tip
+
+Looking for reusable prompts and agent workflows for Conflux eSpace development? Start with [Conflux Skills](../general/build/conflux-skills.md).
+
+:::
+
 ## Acquiring CFX
 
 eSpace also uses CFX as its native currency, which will be needed to pay transaction fees for deploying and interacting with the network.

--- a/docs/general/build/build.md
+++ b/docs/general/build/build.md
@@ -6,6 +6,8 @@ displayed_sidebar: generalSidebar
 
 This section provides documentation related to general Conflux development topics.
 
+Featured resource: [Conflux Skills](./conflux-skills.md), a reusable set of Codex skills for Conflux development, docs lookup, RPC inspection, and testing workflows.
+
 ```mdx-code-block
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/general/build/conflux-skills.md
+++ b/docs/general/build/conflux-skills.md
@@ -11,7 +11,6 @@ keywords:
   - eSpace
   - Core Space
   - ConfluxScan
-  - Integration Testing
 tags: [Skills, AI Tools, Developer Tools]
 ---
 
@@ -22,18 +21,24 @@ tags: [Skills, AI Tools, Developer Tools]
 ## Why use these skills?
 
 - Reuse Conflux-specific workflows without rewriting prompts from scratch.
-- Give coding agents better defaults for eSpace development, docs lookup, RPC inspection, and integration testing.
+- Give coding agents better defaults for eSpace development, docs lookup, and RPC inspection.
 - Keep guidance aligned with official Conflux docs and ecosystem tooling.
 
 ## Install a skill
 
-Use `npx skills add` with the Conflux skills repository and the skill name you want:
+The simplest approach is to give your agent the repository link and ask it to install the skill using its preferred workflow:
+
+```text
+https://github.com/conflux-fans/conflux-skills
+```
+
+If you want to install a specific skill yourself, you can also use `npx skills add`:
 
 ```bash
 npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-dev
 ```
 
-Replace `conflux-dev` with any of the skills listed below.
+Replace `conflux-dev` with the skill you want.
 
 ## Available skills
 
@@ -41,7 +46,6 @@ Replace `conflux-dev` with any of the skills listed below.
 | --- | --- | --- |
 | `conflux-dev` | Build, deploy, verify smart contracts, and integrate frontends or wallets on Conflux eSpace with tools such as Hardhat, Foundry, Remix, ethers, and viem. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-dev` |
 | `conflux-docs` | Find official Conflux documentation for concepts, Core Space and eSpace differences, RPC endpoints, deployment, and developer guides. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-docs` |
-| `conflux-rust-integration-test` | Create or update pytest-based integration tests for `conflux-rust`, including fixture reuse and test debugging patterns. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-rust-integration-test` |
 | `conflux-scan-rpc` | Run read-only eSpace state inspection workflows for transactions, receipts, balances, and contract state through RPC and ConfluxScan APIs. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-scan-rpc` |
 
 ## Suggested use cases
@@ -57,19 +61,6 @@ Use `conflux-docs` when you need official Conflux references quickly, especially
 ### RPC inspection
 
 Use `conflux-scan-rpc` for read-only debugging workflows, such as checking transaction status, balances, receipts, or contract state.
-
-### Core protocol testing
-
-Use `conflux-rust-integration-test` when working on `conflux-rust` integration tests and pytest-based test assets.
-
-## Repository structure
-
-The repository currently groups its references and prompts into four skill directories:
-
-- `conflux-dev`
-- `conflux-docs`
-- `conflux-rust-integration-test`
-- `conflux-scan-rpc`
 
 Browse the full repository here:
 

--- a/docs/general/build/conflux-skills.md
+++ b/docs/general/build/conflux-skills.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 2
+title: Conflux Skills
+description: Reusable Codex skills for Conflux-related development workflows.
+displayed_sidebar: generalSidebar
+keywords:
+  - Conflux Skills
+  - Codex
+  - Skills
+  - Agent workflows
+  - eSpace
+  - Core Space
+  - ConfluxScan
+  - Integration Testing
+tags: [Skills, AI Tools, Developer Tools]
+---
+
+# Conflux Skills
+
+[Conflux Skills](https://github.com/conflux-fans/conflux-skills/tree/main) is a small collection of reusable Codex skills for Conflux-related development workflows. Instead of re-explaining the same Conflux context in every prompt, you can install a skill that already knows the relevant tools, references, and workflows.
+
+## Why use these skills?
+
+- Reuse Conflux-specific workflows without rewriting prompts from scratch.
+- Give coding agents better defaults for eSpace development, docs lookup, RPC inspection, and integration testing.
+- Keep guidance aligned with official Conflux docs and ecosystem tooling.
+
+## Install a skill
+
+Use `npx skills add` with the Conflux skills repository and the skill name you want:
+
+```bash
+npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-dev
+```
+
+Replace `conflux-dev` with any of the skills listed below.
+
+## Available skills
+
+| Skill | What it helps with | Install command |
+| --- | --- | --- |
+| `conflux-dev` | Build, deploy, verify smart contracts, and integrate frontends or wallets on Conflux eSpace with tools such as Hardhat, Foundry, Remix, ethers, and viem. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-dev` |
+| `conflux-docs` | Find official Conflux documentation for concepts, Core Space and eSpace differences, RPC endpoints, deployment, and developer guides. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-docs` |
+| `conflux-rust-integration-test` | Create or update pytest-based integration tests for `conflux-rust`, including fixture reuse and test debugging patterns. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-rust-integration-test` |
+| `conflux-scan-rpc` | Run read-only eSpace state inspection workflows for transactions, receipts, balances, and contract state through RPC and ConfluxScan APIs. | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-scan-rpc` |
+
+## Suggested use cases
+
+### eSpace development
+
+Use `conflux-dev` when you want help with deployment, verification, wallet integration, or common EVM development workflows on Conflux eSpace.
+
+### Documentation lookup
+
+Use `conflux-docs` when you need official Conflux references quickly, especially for space differences, RPC endpoints, and developer onboarding material.
+
+### RPC inspection
+
+Use `conflux-scan-rpc` for read-only debugging workflows, such as checking transaction status, balances, receipts, or contract state.
+
+### Core protocol testing
+
+Use `conflux-rust-integration-test` when working on `conflux-rust` integration tests and pytest-based test assets.
+
+## Repository structure
+
+The repository currently groups its references and prompts into four skill directories:
+
+- `conflux-dev`
+- `conflux-docs`
+- `conflux-rust-integration-test`
+- `conflux-scan-rpc`
+
+Browse the full repository here:
+
+- [conflux-fans/conflux-skills](https://github.com/conflux-fans/conflux-skills/tree/main)

--- a/docs/overview/overview.mdx
+++ b/docs/overview/overview.mdx
@@ -25,6 +25,7 @@ If you have any questions regarding the documentation, feel free to [create an i
 |---|---|
 | [**User Guide**](../espace/UserGuide.md)| A guide for users on configuring MetaMask to interact with Conflux's eSpace.|
 | [**Developer Quickstart**](../espace/DeveloperQuickstart.md) | A quickstart guide for Ethereum developers to configure their development environment for interaction with Conflux's eSpace.|
+| [**Conflux Skills**](../general/build/conflux-skills.md) | Discover reusable Codex skills for Conflux eSpace development, docs lookup, RPC inspection, and related workflows.|
 | [**Developer Tutorials**](/docs/category/tutorials-1) | Developer tutorials for building on Conflux's eSpace, including contract deployment and verification.|
 | [**Cross Space Bridge**](../espace/build/cross-space-bridge.md) | Learn about the cross-space bridge, enabling seamless transfer of assets and data between Conflux's eSpace and Core Space.  |
 | [**Network RPC Endpoints**](../espace/network-endpoints.md) | Find a list of network endpoints for eSpace.|
@@ -38,6 +39,7 @@ If you have any questions regarding the documentation, feel free to [create an i
 |---|---|
 | [**Getting Started with Core Space**](../core/getting-started/getting-started.mdx)| Begin your journey in Conflux's Core Space, understanding its fundamental concepts and operations.|
 | [**Developer Quickstart**](../core/core-developer-quickstart.md)| A quickstart guide for developers to use `js-conflux-sdk` to send their first Core Space transaction.|
+| [**Conflux Skills**](../general/build/conflux-skills.md)| Discover reusable Codex skills for Core Space docs lookup, protocol testing, and other Conflux-focused workflows.|
 | [**Developer Tutorials**](/docs/category/tutorials)| Developer tutorials for building on Core Space, covering contract deployment, contract verification, and Sponsorship.|
 | [**Core Space Basics**](/docs/category/core-space-basics)| Learn about the foundational concepts of Conflux's Core Space, including accounts, transactions, and gas.|
 | [**Core Space Transactions**](/docs/core/core-space-basics/transactions/overview)| Learn about everything about Core Space Transactions, including tx fields, lifecycle, common errors|


### PR DESCRIPTION
## Summary
- add a new `general/build` article introducing the available Conflux Skills and their install commands
- add entry links from the eSpace quickstart, Core quickstart, and overview page
- surface the new article from the general build landing page so it appears naturally in sidebar navigation

## Why
Issue #969 asks for a dedicated article for the Conflux skills repository and quick entry points from key docs sections. This change makes the skills easier to discover without duplicating the upstream repository.

## Validation
- `git diff --check`
- verified links and article references in the updated docs
- based the article content on the current `conflux-fans/conflux-skills` repository structure and README

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/972)
<!-- Reviewable:end -->
