### PR TITLE
[codex] Highlight alternative eSpace RPC providers

### DIFF
--- a/docs/espace/network-endpoints.md
+++ b/docs/espace/network-endpoints.md
@@ -32,6 +32,14 @@ tags: [Network Endpoints]
 
 This page lists the public RPC endpoints for Conflux eSpace. Public RPC endpoints for **Conflux Core Space** is provided [here](../core/core-endpoints.md).
 
+If you need alternatives to Confura, Conflux eSpace also has a dedicated [RPC Providers](./build/infrastructure/RPC-Provider.md) page covering other provider options, including:
+
+- Tenderly
+- Validation Cloud
+- NOWNodes
+- Unifra
+- BlockPi
+
 :::
 
 ## Confura
@@ -127,9 +135,17 @@ import ConfuraError from '../templates/confura-error.md'
 <ConfuraError basicUnitName="block" />
 </details>
 
-## Commercial RPC Service
+## Other RPC Provider Choices
 
-There are couple of commercial RPC service providers, you can check them [here](./build/infrastructure/RPC-Provider.md)
+If Confura is not the right fit for your workload, you can also evaluate the providers listed on the [RPC Providers](./build/infrastructure/RPC-Provider.md) page:
+
+- [Tenderly](./build/infrastructure/RPC-Provider.md#tenderly)
+- [Validation Cloud](./build/infrastructure/RPC-Provider.md#validation-cloud)
+- [NOWNodes](./build/infrastructure/RPC-Provider.md#nownodes)
+- [Unifra](./build/infrastructure/RPC-Provider.md#unifra)
+- [BlockPi](./build/infrastructure/RPC-Provider.md#blockpi)
+
+These options are useful when you want different pricing, service tiers, regional coverage, or provider-specific infrastructure features.
 
 ## FAQs
 


### PR DESCRIPTION
## Summary
- add an introductory tip near the top of the eSpace network endpoints page
- explicitly list the alternative RPC providers already documented elsewhere in the docs
- replace the vague commercial-provider sentence with a clearer provider-choice section and direct links

## Why
Issue #970 points out that the existing provider alternatives are easy to miss. This change surfaces the available options earlier and makes the provider list visible without forcing users to discover it indirectly.

## Validation
- `git diff --check`
- verified provider names and section anchors against `docs/espace/build/infrastructure/RPC-Provider.md`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/973)
<!-- Reviewable:end -->
