### PR TITLE
Rebrand Gnosis Safe to Safe

### DIFF
--- a/docs/espace/build/deployed-contracts.md
+++ b/docs/espace/build/deployed-contracts.md
@@ -9,7 +9,7 @@ keywords:
   - Contract Addresses
   - WCFX9
   - Multicall3
-  - Gnosis Safe
+  - Safe
   - Mainnet
   - Testnet
   - Utility Contracts
@@ -33,12 +33,12 @@ In this article you’ll find useful contract addresses for Conflux eSpace and c
 
 * WCFX9: 0x14b2d3bc65e74dae1030eafd8ac30c533c976a9b
 * Multicall3: 0xEFf0078910f638cd81996cc117bccD3eDf2B072F or 0xcA11bde05977b3631167028862bE2a173976CA11 (Two address contracts are the same, and the latter is the same as the address on other EVM chains.)
-* Gnosis Safe v1.3.0 (Deterministic Deployment Proxy): Check address at [Gnosis Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-130-libs0)
-* Gnosis Safe v1.4.1: Check address at [Gnosis Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-141)
+* Safe v1.3.0 (Deterministic Deployment Proxy): Check address at [Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-130-libs0)
+* Safe v1.4.1: Check address at [Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-141)
 
 ## eSpace testnet
 
 * WCFX9: 0x2ed3dddae5b2f321af0806181fbfa6d049be47d8
 * Multicall3: 0xeff0078910f638cd81996cc117bccd3edf2b072f
-* Gnosis Safe v1.3.0 (Deterministic Deployment Proxy): Check address at [Gnosis Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-130-libs0)
-* Gnosis Safe v1.4.1: Check address at [Gnosis Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-141)
+* Safe v1.3.0 (Deterministic Deployment Proxy): Check address at [Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-130-libs0)
+* Safe v1.4.1: Check address at [Safe](https://github.com/safe-global/safe-contracts/blob/main/CHANGELOG.md#version-141)

--- a/docs/espace/build/infrastructure/gnosis-safe-wallet.md
+++ b/docs/espace/build/infrastructure/gnosis-safe-wallet.md
@@ -1,9 +1,9 @@
 ---
 sidebar_position: 9
-title: Gnosis Safe Wallet
+title: Safe Wallet
 displayed_sidebar: eSpaceSidebar
 keywords:
-  - Gnosis Safe
+  - Safe
   - Multisignature Wallet
   - eSpace
   - DeFi
@@ -23,17 +23,17 @@ keywords:
   - Testnet
   - Wallet Integration
   - Troubleshooting
-tags: [Gnosis Safe]
+tags: [Safe]
 
 ---
 
-[Gnosis Safe Wallet](https://safe.global/) is a renowned multisignature wallet service in the blockchain sector, offering secure fund management solutions. It is particularly popular among Ethereum and EVM (Ethereum Virtual Machine)-compatible blockchain ecosystems. The entire source code for Gnosis Safe, including its smart contracts and both the front-end and back-end code, is open source, ensuring transparency and community trust. In its commitment to innovation, Gnosis Safe has introduced features like account abstraction, further enhancing user experience and security.
+[Safe Wallet](https://safe.global/) is a renowned multisignature wallet service in the blockchain sector, offering secure fund management solutions. It is particularly popular among Ethereum and EVM (Ethereum Virtual Machine)-compatible blockchain ecosystems. The entire source code for Safe, including its smart contracts and both the front-end and back-end code, is open source, ensuring transparency and community trust. In its commitment to innovation, Safe has introduced features like account abstraction, further enhancing user experience and security.
 
-Gnosis Safe Wallet is the chosen fund management tool for numerous DeFi (Decentralized Finance) projects, such as Uniswap, Chainlink, and MakerDAO, among others, highlighting its reliability and wide adoption within the industry.
+Safe Wallet is the chosen fund management tool for numerous DeFi (Decentralized Finance) projects, such as Uniswap, Chainlink, and MakerDAO, among others, highlighting its reliability and wide adoption within the industry.
 
 ### Integration with eSpace
 
-To support developers and DeFi projects within the eSpace ecosystem, eSpace has incorporated the Gnosis Safe Wallet into its infrastructure. [Versions 1.3.0](https://github.com/safe-global/safe-smart-account/blob/main/CHANGELOG.md#version-130-libs0) and [1.4.1](https://github.com/safe-global/safe-smart-account/blob/main/CHANGELOG.md#version-141) of the Safe contract have been deployed on both the eSpace mainnet and testnet, with their address can be found in the changelog. For mainnet users, a dedicated [Safe-Wallet-Web frontend](https://safe.conflux123.xyz/) is available, enabling the creation and management of multisignature accounts for CFX and ERC20 tokens.
+To support developers and DeFi projects within the eSpace ecosystem, eSpace has incorporated the Safe Wallet into its infrastructure. [Versions 1.3.0](https://github.com/safe-global/safe-smart-account/blob/main/CHANGELOG.md#version-130-libs0) and [1.4.1](https://github.com/safe-global/safe-smart-account/blob/main/CHANGELOG.md#version-141) of the Safe contract have been deployed on both the eSpace mainnet and testnet, with their address can be found in the changelog. For mainnet users, a dedicated [Safe-Wallet-Web frontend](https://safe.conflux123.xyz/) is available, enabling the creation and management of multisignature accounts for CFX and ERC20 tokens.
 
 ![](./img/gnosis-safe-web-wallet.png)
 


### PR DESCRIPTION
Gnosis Safe rebranded to "Safe" in July 2022 after spinning out from Gnosis. The legacy gnosis-safe.io domain 301-redirects to safe.global today.

This PR updates body copy on two pages:

- `docs/espace/build/infrastructure/gnosis-safe-wallet.md` — title, keywords, tags, and body now read "Safe" / "Safe Wallet"
- `docs/espace/build/deployed-contracts.md` — body now reads "Safe"

File slugs left unchanged for link continuity. Maintainer can 301 the URLs as a follow-up if desired.

Sent on behalf of the Safe Foundation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/977)
<!-- Reviewable:end -->
