### PR TITLE
docs: add Tenderly free-tier limits to eSpace RPC provider page

### DIFF
--- a/docs/espace/build/infrastructure/RPC-Provider.md
+++ b/docs/espace/build/infrastructure/RPC-Provider.md
@@ -38,6 +38,23 @@ Conflux has partnered with select RPC Providers and also offers its own, similar
 
 Tenderly is a leading full-stack infrastructure platform for web3 Pros, it providing robust Ethereum-compatible RPC services, enabling developers to interact with the blockchain efficiently and reliably. Beyond basic RPC endpoints, Tenderly offers advanced features like real-time transaction simulation, debugging, and analytics, allowing developers to test, monitor, and optimize smart contract interactions with confidence. Its infrastructure is designed to ensure high availability, scalability, and detailed observability for decentralized applications.
 
+### Free tier limits
+
+Tenderly's free plan is sufficient for developing and testing against Conflux eSpace without a paid subscription. At the time of writing, the free tier includes:
+
+- **25 million Tenderly Units (TU) per month** — TUs are Tenderly's usage metric; each RPC request consumes TUs based on the method's computational cost
+- **2 nodes total** (for example, one eSpace mainnet and one eSpace testnet endpoint)
+- **API simulations**: 60 per minute, up to 120K per day and per month
+- **UI simulations**: 50 per month
+- **Monitoring**: 20 monitored addresses and 3 alert rules
+- **1 project**
+
+Create a Conflux eSpace node endpoint from the [Tenderly dashboard](https://dashboard.tenderly.co/), and see [Tenderly's pricing page](https://tenderly.co/pricing) for current plan details.
+
+:::caution
+Tenderly node endpoints embed your access key in the URL (e.g. `https://cfx-espace.gateway.tenderly.co/<your-key>`). Keep the URL in an environment variable rather than committing it to a public repository.
+:::
+
 ## [Validation Cloud](https://www.validationcloud.io/)
 
 Validation Cloud offers an enterprise-grade web3 infrastructure platform covering RPC, Staking, and Data for 50+ leading Web3 blockchains and networks. We are committed to delivering the best performance, reliability and compliance to our users and partners. Validation Cloud is SOC2 Type II certified.

--- a/docs/espace/network-endpoints.md
+++ b/docs/espace/network-endpoints.md
@@ -80,10 +80,10 @@ Chain ID for Conflux eSpace Testnet is `71(0x47)`. The corresponding blockchain 
 
 | RPC Endpoint | Type | Notes |
 | -------- | --- | --- |
+| https://evmtestnet.confluxrpc.com | HTTP ||
 | https://evmtest.confluxrpc.com | HTTP ||
-| https://evmtestnet.confluxrpc.com | HTTP | May be unreachable outside mainland China |
 | https://evmtestnet.confluxrpc.org | HTTP | Backup RPC Service |
-| wss://evmtestnet.confluxrpc.com/ws | Websocket | May be unreachable outside mainland China |
+| wss://evmtestnet.confluxrpc.com/ws | Websocket ||
 | wss://evmtestnet.confluxrpc.org/ws | Websocket ||
 
 ### Rate Limits

--- a/docs/espace/network-endpoints.md
+++ b/docs/espace/network-endpoints.md
@@ -80,10 +80,10 @@ Chain ID for Conflux eSpace Testnet is `71(0x47)`. The corresponding blockchain 
 
 | RPC Endpoint | Type | Notes |
 | -------- | --- | --- |
-| https://evmtestnet.confluxrpc.com | HTTP ||
 | https://evmtest.confluxrpc.com | HTTP ||
+| https://evmtestnet.confluxrpc.com | HTTP | May be unreachable outside mainland China |
 | https://evmtestnet.confluxrpc.org | HTTP | Backup RPC Service |
-| wss://evmtestnet.confluxrpc.com/ws | Websocket ||
+| wss://evmtestnet.confluxrpc.com/ws | Websocket | May be unreachable outside mainland China |
 | wss://evmtestnet.confluxrpc.org/ws | Websocket ||
 
 ### Rate Limits


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://doc.confluxnetwork.org/docs/general/CONTRIBUTING#create-a-pull-request).
- [x] A relating issue is created: # (<- fill the issue number here)
- [x] **This is NOT a PR to submit translation**

## What

Adds a **Free tier limits** section to the Tenderly entry on the [RPC Providers page](https://doc.confluxnetwork.org/docs/espace/build/infrastructure/RPC-Provider), so developers know they can build and test against Conflux eSpace without a paid plan:

- 25 million Tenderly Units (TU) per month
- 2 nodes total (e.g. one mainnet + one testnet endpoint)
- API simulations: 60/min, up to 120K/day and /month; UI simulations: 50/month
- 20 monitored addresses, 3 alert rules, 1 project

Also adds a caution that Tenderly node endpoints embed the access key in the URL, so the URL should live in an environment variable rather than committed config.

Figures are stated as "at the time of writing" and link to [Tenderly's pricing page](https://tenderly.co/pricing) as the source of truth, since plan limits change.

## Testing

Rendered locally with `docusaurus start` — the page renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/984)
<!-- Reviewable:end -->
