### PR TITLE
docs: add Conflux-maintained Pyth-compatible oracle; flag Pyth sunset

### DIFF
--- a/docs/espace/tutorials/oracle/Pyth/priceFeed.md
+++ b/docs/espace/tutorials/oracle/Pyth/priceFeed.md
@@ -36,6 +36,10 @@ tags: [Pyth, Oracles, Tutorial]
 
 # Retrieve Price
 
+:::danger Pyth Network sunset — July 31, 2026
+Pyth Network is **shutting down Conflux eSpace support on July 31, 2026**. After that date, the price feeds used in this tutorial will stop updating. A Conflux-maintained, Pyth-compatible replacement oracle is available — see [Conflux Price Oracle (Pyth-Compatible)](../conflux-oracle.md) for contract addresses and migration steps.
+:::
+
 This tutorial will guide you through building a project on Conflux eSpace using Hardhat and retrieving the CFX price through the Pyth oracle.
 
 ## Prerequisites

--- a/docs/espace/tutorials/oracle/conflux-oracle.md
+++ b/docs/espace/tutorials/oracle/conflux-oracle.md
@@ -28,7 +28,7 @@ Pyth Network has announced it is **shutting down Conflux eSpace support on July 
 A **Conflux-maintained, Pyth-compatible price oracle** is deployed as a drop-in read-side replacement. Existing integrators can migrate by pointing at a new contract address — the read functions and price feed IDs are unchanged for the major assets.
 :::
 
-The replacement oracle is an on-chain price feed service maintained for the Conflux community, with source code at [conflux-fans/oracle-contracts](https://github.com/conflux-fans/oracle-contracts). Its read API is fully compatible with the [Pyth SDK Solidity interface](https://github.com/pyth-network/pyth-sdk-solidity) (`getPriceUnsafe`, `getPriceNoOlderThan`, `getEmaPriceUnsafe`, `getEmaPriceNoOlderThan`), returning the same `PythStructs.Price` type.
+The replacement oracle is an on-chain price feed service maintained for the Conflux community, with source code at [conflux-fans/oracle-contracts](https://github.com/conflux-fans/oracle-contracts). Its spot price read API is compatible with the [Pyth SDK Solidity interface](https://github.com/pyth-network/pyth-sdk-solidity) (`getPriceUnsafe`, `getPriceNoOlderThan`), returning the same `PythStructs.Price` type. The EMA price functions are **not supported** — see [EMA prices are not available](#ema-prices-are-not-available).
 
 ## Contract addresses
 
@@ -56,18 +56,29 @@ All feeds use `expo = -8` (consistent with Pyth crypto feeds): real price = `pri
 Notes:
 
 - The BTC, ETH, USDT, USDC, CFX, and BNB feed IDs are **the same IDs Pyth uses**, so consumers of those feeds do not need to change their stored feed IDs.
-- USDT0 uses the same feed ID as USDT (prices are identical per spec).
+- **There is no separate USDT0 feed.** USDT0 is the [LayerZero OFT form of USDT](https://docs.usdt0.to/), backed 1:1 by USDT locked on Ethereum and operated by Everdawn Labs under licence from Tether, so its price depends on that bridging layer in addition to USDT itself. Consumers that want a USDT0 price from this oracle read the USDT feed.
 - AxCNH/USD is a new feed, with its ID derived from `keccak256("ConfluxOracle.AxCNH/USD")`.
-- EMA read functions exist for compatibility, but **EMA values are not currently updated** — use the spot price functions.
+
+## EMA prices are not available
+
+The oracle does not provide EMA (exponentially-weighted moving average) prices. Use the spot price functions — `getPriceUnsafe` and `getPriceNoOlderThan` — for all reads.
+
+:::warning Mainnet and testnet behave differently
+On **mainnet**, `getEmaPriceUnsafe`, `getEmaPriceNoOlderThan`, and the deprecated `getEmaPrice` all revert with `EmaPrice not supported`, for every feed.
+
+On **testnet**, these calls currently do *not* revert — they return the spot price. Do not treat that as EMA data, and do not rely on it: code that reads EMA prices will appear to work on testnet and then revert on mainnet.
+:::
+
+If you are migrating a contract that reads `getEmaPrice*` from Pyth, switch those call sites to the spot price functions before pointing at this oracle.
 
 ## Migrating from Pyth
 
 The oracle is push-based: authorized updaters publish prices on a roughly hourly schedule. This changes the integration in two ways compared to Pyth's pull model:
 
 1. **Point your consumer contract at the new oracle address** (table above) instead of the Pyth contract address.
-2. **Remove the Hermes/update flow.** There is no `updatePriceFeeds(bytes[])` call to make and no update fee to pay — you only read. Any code that fetched update data from Hermes and attached a fee can be deleted.
+2. **Remove the Hermes/update flow.** `updatePriceFeeds(bytes[])`, `updatePriceFeedsIfNecessary(...)`, and `getUpdateFee(bytes[])` are **not implemented on this contract at all** — there is no update fee and nothing to submit. Leftover calls to them will not silently no-op; they hit the fallback and revert. Delete any code that fetched update data from Hermes and attached a fee.
 
-Since prices update about once per hour, pass an appropriate staleness bound when reading. For example, accepting prices up to 24 hours old:
+Reads take a staleness bound: `getPriceNoOlderThan` reverts with `StalePrice()` when the stored price is older than the bound you pass. Since prices are published about once per hour, a stored price is continuously ageing towards that interval between updates.
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -78,20 +89,29 @@ import {PythStructs} from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
 
 contract CfxPriceConsumer {
     IPyth public immutable oracle;
+    /// @notice Staleness bound in seconds, chosen by the integrator.
+    uint public immutable maxPriceAge;
     bytes32 public constant CFX_USD =
         0x8879170230c9603342f3837cf9a8e76c61791198fb1271bb2552c9af7b33c933;
 
-    constructor(address oracleAddress) {
+    constructor(address oracleAddress, uint maxPriceAge_) {
         oracle = IPyth(oracleAddress);
+        maxPriceAge = maxPriceAge_;
     }
 
     /// @notice Returns the CFX/USD price with expo -8 (price × 10⁻⁸ = USD).
     function getCfxPrice() external view returns (PythStructs.Price memory) {
-        // Reverts if the stored price is older than 24 hours.
-        return oracle.getPriceNoOlderThan(CFX_USD, 86400);
+        // Reverts with StalePrice() if the stored price is older than maxPriceAge.
+        return oracle.getPriceNoOlderThan(CFX_USD, maxPriceAge);
     }
 }
 ```
+
+:::caution Do not use the deprecated `getPrice(bytes32)`
+`getPrice(id)` is exactly `getPriceNoOlderThan(id, getValidTimePeriod())` — it is the same code path, with the contract's own validity window supplied as the bound. That window is currently **3600 seconds**, the same ~1 hour cadence on which prices are published, so any delay in an update pushes the stored price past it and the call reverts with `StalePrice()` (`0x19abf40e`).
+
+Because it is the same code path, passing `3600` to `getPriceNoOlderThan` reproduces the identical behaviour. What makes `getPriceNoOlderThan` usable is choosing a bound with headroom over the publish interval, not the function itself.
+:::
 
 You can verify the oracle is live from the command line:
 
@@ -106,9 +126,11 @@ cast call 0x5286BD91e2C79fE066926a15193C7e531bBF6750 \
 
 Understand the differences from Pyth before relying on the oracle in production:
 
-- **Update cadence is ~1 hour.** This is suitable for slow-moving use cases (collateral valuation with conservative parameters, accounting, display), but not for latency-sensitive applications like liquidation engines tuned to minutes or perps pricing.
+- **Update cadence is ~1 hour.** Prices can therefore be up to roughly an hour behind spot at any given moment.
 - **Push-based with role-based access control.** Prices are published by accounts holding `UPDATER_ROLE`, and the contract is upgradeable by its admin — a different trust model from Pyth's decentralized publisher network. Review the [contract source](https://github.com/conflux-fans/oracle-contracts) and its role holders as part of your own due diligence.
-- Maximum result staleness is controlled by the contract's valid time period and the age bound you pass to `getPriceNoOlderThan`.
+- **Reads revert rather than returning sentinel values.** An unknown feed ID reverts with `PriceFeedNotFound()` (`0x14aebe68`); a price older than the bound passed to `getPriceNoOlderThan` reverts with `StalePrice()` (`0x19abf40e`). Neither returns a zero or a flag, so a failed read propagates as a transaction failure unless the caller explicitly catches it.
+- **`getPriceUnsafe` performs no staleness check.** It returns the stored price at any age, and reverts only when a feed has never been published. If the updater stops — key rotation, infrastructure outage, funding lapse — consumers keep reading the last published price indefinitely, with no revert and no on-chain signal. The returned `publishTime` is the only indication of age. `getPriceNoOlderThan` applies an age bound you supply and reverts with `StalePrice()` when exceeded.
+- **`getValidTimePeriod()` constrains only the deprecated `getPrice` / `getEmaPrice`.** For `getPriceNoOlderThan`, the bound you pass is the only value consulted — the contract's validity window plays no part.
 
 ## Further reading
 

--- a/docs/espace/tutorials/oracle/conflux-oracle.md
+++ b/docs/espace/tutorials/oracle/conflux-oracle.md
@@ -1,0 +1,116 @@
+---
+sidebar_position: 2
+title: Conflux Price Oracle (Pyth-Compatible)
+description: Migrate from Pyth Network to the Conflux-maintained price oracle before the July 31, 2026 sunset
+keywords:
+  - Conflux eSpace
+  - Oracle
+  - Price Feed
+  - Pyth Network
+  - Pyth sunset
+  - Migration
+  - Smart Contracts
+  - Solidity
+  - Price Feed ID
+  - CFX Price
+  - Mainnet
+  - Testnet
+  - Contract Addresses
+displayed_sidebar: eSpaceSidebar
+tags: [Oracles, Pyth, Migration]
+---
+
+# Conflux Price Oracle (Pyth-Compatible)
+
+:::danger Pyth Network sunset — July 31, 2026
+Pyth Network has announced it is **shutting down Conflux eSpace support on July 31, 2026**. Contracts that read prices from the Pyth contract on eSpace will stop receiving updates after that date.
+
+A **Conflux-maintained, Pyth-compatible price oracle** is deployed as a drop-in read-side replacement. Existing integrators can migrate by pointing at a new contract address — the read functions and price feed IDs are unchanged for the major assets.
+:::
+
+The replacement oracle is an on-chain price feed service maintained for the Conflux community, with source code at [conflux-fans/oracle-contracts](https://github.com/conflux-fans/oracle-contracts). Its read API is fully compatible with the [Pyth SDK Solidity interface](https://github.com/pyth-network/pyth-sdk-solidity) (`getPriceUnsafe`, `getPriceNoOlderThan`, `getEmaPriceUnsafe`, `getEmaPriceNoOlderThan`), returning the same `PythStructs.Price` type.
+
+## Contract addresses
+
+| Network | Address |
+| --- | --- |
+| Conflux eSpace Mainnet (chain id 1030) | `0x5286BD91e2C79fE066926a15193C7e531bBF6750` |
+| Conflux eSpace Testnet (chain id 71) | `0x838c40B3904FAfBc21b670c97b0dFeE7D8D0a016` |
+
+These are the proxy addresses — the oracle uses a UUPS upgradeable proxy, so the address stays stable across logic upgrades. Always integrate against the proxy.
+
+## Supported price feeds
+
+All feeds use `expo = -8` (consistent with Pyth crypto feeds): real price = `price × 10⁻⁸`.
+
+| Asset | Price Feed ID (bytes32) | Update Frequency |
+| --- | --- | --- |
+| BTC/USD | `0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43` | 1h |
+| ETH/USD | `0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace` | 1h |
+| USDT/USD | `0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b` | 1h |
+| USDC/USD | `0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a` | 1h |
+| CFX/USD | `0x8879170230c9603342f3837cf9a8e76c61791198fb1271bb2552c9af7b33c933` | 1h |
+| BNB/USD | `0x2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f` | 1h |
+| AxCNH/USD | `0x6412f0e5469e5ab64fccf0eea916ae6db2bcd56568daaaf583b3054d465e8e2d` | 1h |
+
+Notes:
+
+- The BTC, ETH, USDT, USDC, CFX, and BNB feed IDs are **the same IDs Pyth uses**, so consumers of those feeds do not need to change their stored feed IDs.
+- USDT0 uses the same feed ID as USDT (prices are identical per spec).
+- AxCNH/USD is a new feed, with its ID derived from `keccak256("ConfluxOracle.AxCNH/USD")`.
+- EMA read functions exist for compatibility, but **EMA values are not currently updated** — use the spot price functions.
+
+## Migrating from Pyth
+
+The oracle is push-based: authorized updaters publish prices on a roughly hourly schedule. This changes the integration in two ways compared to Pyth's pull model:
+
+1. **Point your consumer contract at the new oracle address** (table above) instead of the Pyth contract address.
+2. **Remove the Hermes/update flow.** There is no `updatePriceFeeds(bytes[])` call to make and no update fee to pay — you only read. Any code that fetched update data from Hermes and attached a fee can be deleted.
+
+Since prices update about once per hour, pass an appropriate staleness bound when reading. For example, accepting prices up to 24 hours old:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {IPyth} from "@pythnetwork/pyth-sdk-solidity/IPyth.sol";
+import {PythStructs} from "@pythnetwork/pyth-sdk-solidity/PythStructs.sol";
+
+contract CfxPriceConsumer {
+    IPyth public immutable oracle;
+    bytes32 public constant CFX_USD =
+        0x8879170230c9603342f3837cf9a8e76c61791198fb1271bb2552c9af7b33c933;
+
+    constructor(address oracleAddress) {
+        oracle = IPyth(oracleAddress);
+    }
+
+    /// @notice Returns the CFX/USD price with expo -8 (price × 10⁻⁸ = USD).
+    function getCfxPrice() external view returns (PythStructs.Price memory) {
+        // Reverts if the stored price is older than 24 hours.
+        return oracle.getPriceNoOlderThan(CFX_USD, 86400);
+    }
+}
+```
+
+You can verify the oracle is live from the command line:
+
+```bash
+cast call 0x5286BD91e2C79fE066926a15193C7e531bBF6750 \
+  "getPriceUnsafe(bytes32)((int64,uint64,int32,uint256))" \
+  0x8879170230c9603342f3837cf9a8e76c61791198fb1271bb2552c9af7b33c933 \
+  --rpc-url https://evm.confluxrpc.com
+```
+
+## Trust and limitations
+
+Understand the differences from Pyth before relying on the oracle in production:
+
+- **Update cadence is ~1 hour.** This is suitable for slow-moving use cases (collateral valuation with conservative parameters, accounting, display), but not for latency-sensitive applications like liquidation engines tuned to minutes or perps pricing.
+- **Push-based with role-based access control.** Prices are published by accounts holding `UPDATER_ROLE`, and the contract is upgradeable by its admin — a different trust model from Pyth's decentralized publisher network. Review the [contract source](https://github.com/conflux-fans/oracle-contracts) and its role holders as part of your own due diligence.
+- Maximum result staleness is controlled by the contract's valid time period and the age bound you pass to `getPriceNoOlderThan`.
+
+## Further reading
+
+- [conflux-fans/oracle-contracts](https://github.com/conflux-fans/oracle-contracts) — source, deployment scripts, and integration examples
+- [Pyth tutorial](./Pyth/priceFeed.md) — the original Pyth integration tutorial (applicable until the sunset date)


### PR DESCRIPTION
## What

Pyth Network has announced it is **shutting down Conflux eSpace support on July 31, 2026**. This PR prepares the oracle docs:

1. **New page: Conflux Price Oracle (Pyth-Compatible)** — documents the Conflux-maintained drop-in replacement ([conflux-fans/oracle-contracts](https://github.com/conflux-fans/oracle-contracts)):
   - Mainnet proxy `0x5286BD91e2C79fE066926a15193C7e531bBF6750` and testnet proxy `0x838c40B3904FAfBc21b670c97b0dFeE7D8D0a016`
   - Supported price feeds (BTC, ETH, USDT, USDC, CFX, BNB — same feed IDs as Pyth — plus AxCNH), all expo -8, ~1h update cadence
   - Migration guide from Pyth's pull model (no Hermes update flow, no update fee — read-only integration) with a Solidity consumer example and a `cast` liveness check
   - Trust/limitation notes: 1h cadence, role-based updaters, UUPS upgradeability
2. **Sunset warning on the existing Pyth tutorial** linking to the migration page.

## Verification

- Confirmed on-chain that both proxies and their implementations have deployed code, and that the mainnet oracle serves a current CFX/USD price via `getPriceUnsafe` (queried during authoring).
- Rendered locally with `docusaurus start` — both pages render, links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/985)
<!-- Reviewable:end -->
