### PR TITLE
docs: add v3.1 hardfork article

### DIFF
--- a/docs/general/hardforks/v3.1.md
+++ b/docs/general/hardforks/v3.1.md
@@ -31,7 +31,7 @@ Conflux v3.1.0 is a hardfork introducing EVM compatibility changes from Ethereum
 - Security update: this upgrade includes a fix for a security issue. To prevent exploitation, the related source code and details will be published after the network upgrade is complete.
 - RPC changes:
   - New RPCs: eSpace `eth_createAccessList` and eSpace parity style `trace_call`.
-  - The Core space RPC service has been migrated to the `jsonrpsee` framework, so JSON-RPC error messages differ from previous versions.
+  - The Core space RPC service has been migrated to the `jsonrpsee` framework.
   - The TCP JSON-RPC server has been removed, along with the `jsonrpc_tcp_port` and `jsonrpc_local_tcp_port` options. The HTTP and WebSocket endpoints are unchanged.
   - The WebSocket endpoint now applies the `jsonrpc_cors` setting, which previously affected HTTP only.
   - Request throttling is enforced on the `jsonrpsee` stack and now also covers batch requests.

--- a/docs/general/hardforks/v3.1.md
+++ b/docs/general/hardforks/v3.1.md
@@ -1,0 +1,91 @@
+---
+title: v3.1
+displayed_sidebar: generalSidebar
+toc_max_heading_level: 4
+keywords: [Conflux Network, v3.1 hardfork, CIPs]
+tags: [Hard Forks]
+---
+---
+
+| Key Information | Details |
+| --- | --- |
+| Version | Conflux v3.1.0 |
+| Hardfork Introduced | Yes |
+| Incompatible Changes | Yes (CIP-166, CIP-167, CIP-172, CIP-173, CIP-174, CIP-175, CIP-176) |
+
+## Introduction
+
+Conflux v3.1.0 is a hardfork introducing EVM compatibility changes from Ethereum's Osaka upgrade, bug fixes, a security update (details disclosed after activation), and RPC changes.
+
+### Upgrade Overview
+
+- EVM compatibility:
+  - The `CLZ` opcode for counting leading zeros is introduced ([CIP-166](#cip-166)).
+  - A precompile for secp256r1 (P-256) signature verification is introduced, the curve widely used by WebAuthn and passkeys ([CIP-167](#cip-167)).
+  - The ModExp precompile gets an upper bound on input length and repriced gas ([CIP-174](#cip-174)).
+- Bug fixes:
+  - Every transaction in a block must use canonical RLP encoding, fixing the issue where the same transaction could correspond to more than one hash ([CIP-172](#cip-172)).
+  - PoS dispute evidence verification defects are fixed, and the [CIP-156](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-156.md) stake lock is extended to validators whose stake is already entirely unlocking ([CIP-173](#cip-173)).
+  - Cross-space calls now resolve EIP-7702 delegation, matching calls made within eSpace ([CIP-175](#cip-175)).
+  - Access list entries for the same address all warm their storage keys, instead of only the last entry ([CIP-176](#cip-176)).
+- Security update: this upgrade includes a fix for a security issue. To prevent exploitation, the related source code and details will be published after the network upgrade is complete.
+- RPC changes:
+  - New RPCs: eSpace `eth_createAccessList` and eSpace parity style `trace_call`.
+  - The Core space RPC service has been migrated to the `jsonrpsee` framework, so JSON-RPC error messages differ from previous versions.
+  - The TCP JSON-RPC server has been removed, along with the `jsonrpc_tcp_port` and `jsonrpc_local_tcp_port` options. The HTTP and WebSocket endpoints are unchanged.
+  - The WebSocket endpoint now applies the `jsonrpc_cors` setting, which previously affected HTTP only.
+  - Request throttling is enforced on the `jsonrpsee` stack and now also covers batch requests.
+  - The light node supports the pub/sub namespace.
+  - Fixed `4byteTracer` dropping calls with no arguments (bare function selector).
+  - Fixed phantom transaction trace recovery for blocks before CIP-90 activation.
+  - eSpace log filters reject a `topics` array with more than four positions.
+  - EIP-7702 authorization objects reject a `yParity` greater than 1.
+  - `cfx_sendTransaction` and `cfx_signTransaction` return an error when `from` is omitted.
+  - The PoS `tx_by_version` RPC returns `null` for version 0.
+
+### Upgrade Notes
+
+1. Replace `pos_config/pos_config.yaml` with the copy shipped in this release. The file is parsed strictly and an old copy will not load, so the node will not start. If you changed paths such as `base.data_dir`, `storage.dir` or `logger.file`, carry them over — those keys are unchanged. `pos_config/genesis_file` is no longer used and can be deleted.
+2. The first start after upgrading will take considerably longer than a normal restart. The shipped `run/testnet.toml` now sets `use_isolated_db_for_mpt_table = true`, and the node rebuilds the latest MPT snapshot once to make that switch. Later restarts are unaffected.
+
+### CIP List
+
+#### CIP-166
+
+[CIP-166 Add CLZ Opcode](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-166.md) replicates [EIP-7939](https://eips.ethereum.org/EIPS/eip-7939), adding the `CLZ` opcode for counting leading zeros.
+
+#### CIP-167
+
+[CIP-167 Precompile for secp256r1 Signature Verification](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-167.md) replicates [EIP-7951](https://eips.ethereum.org/EIPS/eip-7951), introducing a precompile for signature verification on the secp256r1 (P-256) curve, which is widely used by WebAuthn, passkeys and similar schemes.
+
+#### CIP-172
+
+[CIP-172 Enforce Canonical RLP Encoding for Transactions](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-172.md) requires every transaction in a block to use canonical RLP encoding, fixing an issue where the same transaction could correspond to more than one hash. Nodes also reject these transactions from the transaction pool immediately upon upgrade, without waiting for activation.
+
+#### CIP-173
+
+[CIP-173 Fix PoS Dispute Evidence Verification](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-173.md) fixes defects in the verification of PoS dispute evidence, and extends the [CIP-156](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-156.md) stake lock to a validator whose stake is already entirely unlocking.
+
+#### CIP-174
+
+[CIP-174 Bound ModExp Precompile Input Length](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-174.md) replicates [EIP-7823](https://eips.ethereum.org/EIPS/eip-7823) and [EIP-7883](https://eips.ethereum.org/EIPS/eip-7883), setting an upper bound on the input lengths of the ModExp precompile and raising its gas pricing.
+
+#### CIP-175
+
+[CIP-175 Resolve EIP-7702 Delegation in Cross-Space Calls](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-175.md) fixes cross-space calls not resolving an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) delegation, bringing the behavior in line with calls made within eSpace.
+
+#### CIP-176
+
+[CIP-176 Fix Access List Storage Key Warming](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-176.md) fixes the case where, when the same address appears in several entries of an access list, only the storage keys of the last entry were warmed.
+
+## Releases
+
+### Testnet
+
+| Key Information | Details |
+| --- | --- |
+| Release | [Conflux v3.1.0-testnet](https://github.com/Conflux-Chain/conflux-rust/releases/tag/v3.1.0-testnet) |
+| Announcement | [Conflux v3.1.0-testnet Hardfork Upgrade Announcement (August 3, 2026)](https://forum.conflux.fun/t/conflux-v3-1-0-testnet-hardfork-20260803/23981) |
+| Deadlines | <ul><li>**Node Upgrade:** Before epoch number reaches 259240000 (estimated on August 7th 2026)</li><li>**CIP-173 Activation:** When PoS block number reaches 3870720 (estimated on August 8th 2026)</li></ul> |
+
+The mainnet release will be published after the testnet upgrade completes.


### PR DESCRIPTION
## What changed

Added `docs/general/hardforks/v3.1.md`, documenting the Conflux v3.1.0 hardfork following the existing v3.0 article structure: upgrade overview, RPC changes, upgrade notes, per-CIP details (CIP-166, CIP-167, CIP-172, CIP-173, CIP-174, CIP-175, CIP-176), the deferred security update, and the testnet release deadlines.

## Why

Conflux v3.1.0-testnet introduces a new hardfork scheduled for early August 2026; the docs need an article ahead of the testnet upgrade.

## Impact

Site visitors get an accurate reference for the v3.1 hardfork CIPs, RPC changes, and node upgrade deadlines. No existing pages are modified.

## Validation

- `npx docusaurus build` succeeds; the page is generated in the default and translated builds.
- Front-matter dry run confirms no missing front matter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/conflux-documentation/995)
<!-- Reviewable:end -->
